### PR TITLE
IPAddress: Fixes #323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   - Updated Year to 2018 in License and Manifest.
   - Updated README.md from xNetworking to NetworkingDsc.
 - MSFT_IPAddress:
-  - Updated to allow setting multiple IP Addresses when one is already set - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
+  - Updated to allow setting multiple IP Addresses
+    when one is already set - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
 
 ## 5.7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   - Updated Year to 2018 in License and Manifest.
   - Updated README.md from xNetworking to NetworkingDsc.
 - MSFT_IPAddress:
-  - Fixed bug in `Set-TargetResource` where it would fail setting multiple IP Addresses if one was already set - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
+  - Updated to allow setting multiple IP Addresses when one is already set.
+  - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
 
 ## 5.7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@
   - Updated Year to 2018 in License and Manifest.
   - Updated README.md from xNetworking to NetworkingDsc.
 - MSFT_IPAddress:
-  - Updated to allow setting multiple IP Addresses when one is already set.
-  - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
+  - Updated to allow setting multiple IP Addresses when one is already set - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
 
 ## 5.7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - Updated DSCResources, Examples, Modules and Tests with new naming.
   - Updated Year to 2018 in License and Manifest.
   - Updated README.md from xNetworking to NetworkingDsc.
+- MSFT_IPAddress:
+  - Fixed bug in `Set-TargetResource` where it would fail setting multiple IP Addresses if one was already set - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
 
 ## 5.7.0.0
 

--- a/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/MSFT_IPAddress.psm1
+++ b/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/MSFT_IPAddress.psm1
@@ -224,6 +224,7 @@ function Set-TargetResource
         }
         catch [Microsoft.Management.Infrastructure.CimException]
         {
+            # The IP Address is already set
             Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
                 $($LocalizedData.IPAddressMatchMessage)
                 ) -join '' )

--- a/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/MSFT_IPAddress.psm1
+++ b/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/MSFT_IPAddress.psm1
@@ -238,8 +238,8 @@ function Set-TargetResource
             {
                 # The IP Address is already set on the correct interface
                 Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-                $($LocalizedData.IPAddressMatchMessage)
-                ) -join '' )
+                        $($LocalizedData.IPAddressMatchMessage)
+                    ) -join '' )
             }
             else
             {

--- a/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/MSFT_IPAddress.psm1
+++ b/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/MSFT_IPAddress.psm1
@@ -234,7 +234,7 @@ function Set-TargetResource
             #>
             $verifyNetIPAddressAdapter = Get-NetIPAddress @verifyNetIPAddressAdapterParam -ErrorAction SilentlyContinue
 
-            if($verifyNetIPAddressAdapter.InterfaceAlias -eq $InterfaceAlias)
+            if ($verifyNetIPAddressAdapter.InterfaceAlias -eq $InterfaceAlias)
             {
                 # The IP Address is already set on the correct interface
                 Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "

--- a/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/en-US/MSFT_IPAddress.strings.psd1
+++ b/Modules/NetworkingDsc/DSCResources/MSFT_IPAddress/en-US/MSFT_IPAddress.strings.psd1
@@ -7,6 +7,7 @@ ConvertFrom-StringData @'
     CheckingIPAddressMessage = Checking the IP Address.
     IPAddressDoesNotMatchMessage = IP Address does NOT match desired state. Expected {0}, actual {1}.
     IPAddressMatchMessage = IP Address is in desired state.
+    IPAddressDoesNotMatchInterfaceAliasMessage = IP Address set on different InterfaceAlias. Expected {0}, actual {1}.
     PrefixLengthDoesNotMatchMessage = Prefix Length does NOT match desired state. Expected {0}, actual {1}.
     PrefixLengthMatchMessage = Prefix Length is in desired state.
     DHCPIsNotDisabledMessage = DHCP is NOT disabled.

--- a/Tests/Integration/MSFT_IPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_IPAddress.Integration.Tests.ps1
@@ -21,6 +21,7 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Configure Loopback Adapter
 . (Join-Path -Path (Split-Path -Parent $Script:MyInvocation.MyCommand.Path) -ChildPath 'IntegrationHelper.ps1')
 New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA'
+New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
 
 # Using try/finally to always cleanup even if something awful happens.
 try
@@ -54,9 +55,12 @@ try
             $current = Get-DscConfiguration | Where-Object -FilterScript {
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
-            $current.InterfaceAlias | Should -Be $TestIPAddress.InterfaceAlias
-            $current.AddressFamily  | Should -Be $TestIPAddress.AddressFamily
-            $current.IPAddress      | Should -Be $TestIPAddress.IPAddress
+            $current[0].InterfaceAlias | Should -Be $TestIPAddress.InterfaceAlias
+            $current[0].AddressFamily  | Should -Be $TestIPAddress.AddressFamily
+            $current[0].IPAddress      | Should -Be $TestIPAddress.IPAddress
+            $current[1].InterfaceAlias | Should -Be $TestMultipleIPAddress.InterfaceAlias
+            $current[1].AddressFamily  | Should -Be $TestMultipleIPAddress.AddressFamily
+            $current[1].IPAddress      | Should -Be $TestMultipleIPAddress.IPAddress
         }
     }
     #endregion
@@ -65,6 +69,7 @@ finally
 {
     # Remove Loopback Adapter
     Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA'
+    Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
 
     #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment

--- a/Tests/Integration/MSFT_IPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_IPAddress.Integration.Tests.ps1
@@ -60,7 +60,8 @@ try
             $current[0].IPAddress      | Should -Be $TestIPAddress.IPAddress
             $current[1].InterfaceAlias | Should -Be $TestMultipleIPAddress.InterfaceAlias
             $current[1].AddressFamily  | Should -Be $TestMultipleIPAddress.AddressFamily
-            $current[1].IPAddress      | Should -Be $TestMultipleIPAddress.IPAddress
+            $current[1].IPAddress      | Should -Contain $TestMultipleIPAddress.IPAddress[0]
+            $current[1].IPAddress      | Should -Contain $TestMultipleIPAddress.IPAddress[1]
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_IPAddress.config.ps1
+++ b/Tests/Integration/MSFT_IPAddress.config.ps1
@@ -6,7 +6,7 @@ $TestIPAddress = [PSObject]@{
 $TestMultipleIPAddress = [PSObject]@{
     InterfaceAlias          = 'NetworkingDscLBA2'
     AddressFamily           = 'IPv4'
-    IPAddress               = @('10.11.12.13/16','10.13.14.16/32')
+    IPAddress               = @('10.12.13.14/16','10.13.14.16/32')
 }
 
 configuration MSFT_IPAddress_Config {

--- a/Tests/Integration/MSFT_IPAddress.config.ps1
+++ b/Tests/Integration/MSFT_IPAddress.config.ps1
@@ -3,6 +3,11 @@ $TestIPAddress = [PSObject]@{
     AddressFamily           = 'IPv4'
     IPAddress               = '10.11.12.13/16'
 }
+$TestMultipleIPAddress = [PSObject]@{
+    InterfaceAlias          = 'NetworkingDscLBA2'
+    AddressFamily           = 'IPv4'
+    IPAddress               = @('10.11.12.13/16','10.13.14.16/32')
+}
 
 configuration MSFT_IPAddress_Config {
     Import-DscResource -ModuleName NetworkingDsc
@@ -12,6 +17,11 @@ configuration MSFT_IPAddress_Config {
             InterfaceAlias          = $TestIPAddress.InterfaceAlias
             AddressFamily           = $TestIPAddress.AddressFamily
             IPAddress               = $TestIPAddress.IPAddress
+        }
+        IPAddress Integration_Test2 {
+            InterfaceAlias          = $TestMultipleIPAddress.InterfaceAlias
+            AddressFamily           = $TestMultipleIPAddress.AddressFamily
+            IPAddress               = $TestMultipleIPAddress.IPAddress
         }
     }
 }

--- a/Tests/Unit/MSFT_IPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_IPAddress.Tests.ps1
@@ -170,7 +170,6 @@ try
 
                         { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                         $result | Should -BeNullOrEmpty
-
                     }
 
                     It 'Should call all the mocks' {

--- a/Tests/Unit/MSFT_IPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_IPAddress.Tests.ps1
@@ -117,7 +117,7 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -137,11 +137,30 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 2
+                    }
+                }
+                Context 'Invoked with multiple valid IP Addresses with one currently set' {
+                    It 'Should return $null' {
+                        $setTargetResourceParameters = @{
+                            IPAddress      = @('192.168.0.1/16', '10.0.0.3/24')
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                        }
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
+                        Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
+                        Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 0
+                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 1
                     }
                 }
 
@@ -158,7 +177,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -182,7 +201,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -205,7 +224,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -258,7 +277,7 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -279,7 +298,7 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -300,7 +319,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -358,11 +377,11 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
-                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 1
                     }
                 }
 
@@ -379,7 +398,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 2

--- a/Tests/Unit/MSFT_IPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_IPAddress.Tests.ps1
@@ -166,7 +166,7 @@ try
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 0
-                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 2
                     }
                 }
 
@@ -387,7 +387,7 @@ try
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
-                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 2
                     }
                 }
 

--- a/Tests/Unit/MSFT_IPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_IPAddress.Tests.ps1
@@ -144,7 +144,46 @@ try
                         Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 2
                     }
                 }
+
                 Context 'Invoked with multiple valid IP Addresses with one currently set' {
+                    It 'Should return $null' {
+                        $setTargetResourceParameters = @{
+                            IPAddress      = @('192.168.0.1/16', '10.0.0.3/24')
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                        }
+
+                        Mock -CommandName New-NetIPAddress -MockWith {
+                            throw [Microsoft.Management.Infrastructure.CimException] 'InvalidOperation'
+                        } -ParameterFilter { $IPaddress -eq '192.168.0.1' }
+
+                        Mock -CommandName Get-NetIPAddress -MockWith {
+                            [PSCustomObject] @{
+                                IPAddress      = '192.168.0.1'
+                                InterfaceAlias = 'Ethernet'
+                                PrefixLength   = [System.Byte] 16
+                                AddressFamily  = 'IPv4'
+                            }
+                        } -ParameterFilter { $IPaddress -eq '192.168.0.1' }
+
+                        Mock -CommandName Write-Error
+
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
+
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
+                        Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
+                        Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 0
+                        Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Write-Error -Exactly -Times 0
+                    }
+                }
+
+                Context 'Invoked with multiple valid IP Addresses with one currently set on another adapter' {
                     It 'Should return $null' {
                         $setTargetResourceParameters = @{
                             IPAddress      = @('192.168.0.1/16', '10.0.0.3/24')

--- a/Tests/Unit/MSFT_IPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_IPAddress.Tests.ps1
@@ -117,7 +117,7 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -137,7 +137,7 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -151,12 +151,18 @@ try
                             InterfaceAlias = 'Ethernet'
                             AddressFamily  = 'IPv4'
                         }
+
+                        Mock -CommandName New-NetIPAddress -MockWith {
+                            throw [Microsoft.Management.Infrastructure.CimException] 'InvalidOperation'
+                        } -ParameterFilter { $IPaddress -eq '192.168.0.1' }
+
                         { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                         $result | Should -BeNullOrEmpty
+
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 0
@@ -177,7 +183,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -201,7 +207,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -224,7 +230,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -277,7 +283,7 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -298,7 +304,7 @@ try
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -319,7 +325,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -377,7 +383,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 1
@@ -398,7 +404,7 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 2

--- a/Tests/Unit/MSFT_IPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_IPAddress.Tests.ps1
@@ -156,17 +156,29 @@ try
                             throw [Microsoft.Management.Infrastructure.CimException] 'InvalidOperation'
                         } -ParameterFilter { $IPaddress -eq '192.168.0.1' }
 
+                        Mock -CommandName Get-NetIPAddress -MockWith {
+                            [PSCustomObject] @{
+                                IPAddress      = '192.168.0.1'
+                                InterfaceAlias = 'Ethernet2'
+                                PrefixLength   = [System.Byte] 16
+                                AddressFamily  = 'IPv4'
+                            }
+                        } -ParameterFilter { $IPaddress -eq '192.168.0.1' }
+
+                        Mock -CommandName Write-Error
+
                         { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                         $result | Should -BeNullOrEmpty
 
                     }
 
                     It 'Should call all the mocks' {
-                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 2
                         Assert-MockCalled -CommandName Get-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetRoute -Exactly -Times 1
                         Assert-MockCalled -CommandName Remove-NetIPAddress -Exactly -Times 0
                         Assert-MockCalled -CommandName New-NetIPAddress -Exactly -Times 2
+                        Assert-MockCalled -CommandName Write-Error -Exactly -Times 1
                     }
                 }
 


### PR DESCRIPTION
**Pull Request (PR) description**
Fixes bug in Set-TargetResource where it would fail setting multiple IP Addresses if one was already set

**This Pull Request (PR) fixes the following issues:**
Fixes #323 

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/networkingdsc/331)
<!-- Reviewable:end -->
