### PR TITLE
Correction to CHANGELOG.MD - Fixes #315

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - MSFT_IPAddress:
   - Updated to allow setting multiple IP Addresses
     when one is already set - Fixes [Issue #323](https://github.com/PowerShell/NetworkingDsc/issues/323)
+- Corrected CHANGELOG.MD to report that issue with InterfaceAlias matching
+  on Adapter description rather than Adapter Name was released in 5.7.0.0
+  rather than 5.6.0.0 - See [Issue #315](https://github.com/PowerShell/xNetworking/issues/315).
 
 ## 5.7.0.0
 
@@ -20,6 +23,9 @@
 - MSFT_xNetAdapterAdvancedProperty:
   - Enabled setting the same property on multiple network
     adapters - Fixes [issue #324](https://github.com/PowerShell/xNetworking/issues/324).
+- MSFT_xNetBIOS:
+  - Fix issue with InterfaceAlias matching on Adapter description
+    rather than Adapter Name - Fixes [Issue #315](https://github.com/PowerShell/xNetworking/issues/315).
 
 ## 5.6.0.0
 
@@ -36,8 +42,6 @@
 - MSFT_xNetBIOS:
   - Corrected style and formatting to meet HQRM guidelines.
   - Ensured CommonTestHelper.psm1 is loaded before running unit tests.
-  - Fix issue with InterfaceAlias matching on Adapter description
-    rather than Adapter Name - Fixes [Issue #315](https://github.com/PowerShell/xNetworking/issues/315).
 - MSFT_xNetworkTeam:
   - Corrected style and formatting to meet HQRM guidelines.
   - Added missing default from MOF description of Ensure parameter.


### PR DESCRIPTION
**Pull Request (PR) description**
Corrected CHANGELOG.MD to report that issue with InterfaceAlias matching
on Adapter description rather than Adapter Name was released in 5.7.0.0
rather than 5.6.0.0 - See [Issue #315](https://github.com/PowerShell/xNetworking/issues/315).


**This Pull Request (PR) fixes the following issues:**
- Fixes #315

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - would you mind reviewing?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/networkingdsc/336)
<!-- Reviewable:end -->
