### PR TITLE
Change NetWorkteam Get-TargetResource to improve behaviour - Fixes #342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   - Updated examples to use NetIPInterface.
 - MSFT_DnsServerAddress:
   - Updated examples to use NetIPInterface.
+- MSFT_NetworkTeam:
+  - Change `Get-TargetResource` to return actual TeamMembers if network team
+    exists and 'Ensure' returns 'Present' even when actual TeamMembers do
+    not match 'TeamMembers' parameter - fixes [Issue #342](https://github.com/PowerShell/NetworkingDsc/issues/342).
 
 ## 6.3.0.0
 

--- a/Modules/NetworkingDsc/DSCResources/MSFT_NetworkTeam/MSFT_NetworkTeam.psm1
+++ b/Modules/NetworkingDsc/DSCResources/MSFT_NetworkTeam/MSFT_NetworkTeam.psm1
@@ -55,14 +55,15 @@ Function Get-TargetResource
         Write-Verbose -Message ($localizedData.FoundTeam -f $Name)
         $configuration.Add('LoadBalancingAlgorithm', $networkTeam.LoadBalancingAlgorithm)
         $configuration.Add('TeamingMode', $networkTeam.TeamingMode)
+        $configuration.Ensure = 'Present'
 
         if ($null -eq (Compare-Object -ReferenceObject $TeamMembers -DifferenceObject $networkTeam.Members))
         {
             Write-Verbose -Message ($localizedData.TeamMembersMatch -f $Name)
-            $configuration.Ensure = 'Present'
         }
         else
         {
+            $configuration.TeamMembers = $networkTeam.Members
             Write-Verbose -Message ($localizedData.TeamMembersNotMatch -f $Name)
         }
     }

--- a/Tests/Unit/MSFT_NetworkTeam.Tests.ps1
+++ b/Tests/Unit/MSFT_NetworkTeam.Tests.ps1
@@ -100,9 +100,9 @@ try
                 }
 
                 It 'Should return team properties' {
-                    $result.Ensure                 | Should -Be 'Absent'
+                    $result.Ensure                 | Should -Be 'Present'
                     $result.Name                   | Should -Be $testTeam.Name
-                    $result.TeamMembers            | Should -Be @('NIC1','NIC3')
+                    $result.TeamMembers            | Should -Be @('NIC1','NIC2')
                     $result.LoadBalancingAlgorithm | Should -Be 'Dynamic'
                     $result.TeamingMode            | Should -Be 'SwitchIndependent'
                 }


### PR DESCRIPTION
#### Pull Request (PR) description

Change `Get-TargetResource` to return actual TeamMembers if network team exists and 'Ensure' returns 'Present' even when actual TeamMembers do not match 'TeamMembers' parameter.

#### This Pull Request (PR) fixes the following issues

- Fixes #342 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing if you have time? Hopefully a short one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/networkingdsc/373)
<!-- Reviewable:end -->
