### PR TITLE
MSFT_Proxy - Fix Strings Parameters longer than 255 chars - Fixes #378

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- MSFT_Proxy:
+  - Fixed `ProxyServer`, `ProxyServerExceptions` and `AutoConfigURL`
+    parameters so that they correctly support strings longer than 255
+    characters - fixes [Issue #378](https://github.com/PowerShell/NetworkingDsc/issues/378).
+
 ## 7.0.0.0
 
 - Refactored module folder structure to move resource to root folder of

--- a/DSCResources/MSFT_ProxySettings/MSFT_ProxySettings.psm1
+++ b/DSCResources/MSFT_ProxySettings/MSFT_ProxySettings.psm1
@@ -604,9 +604,9 @@ function Get-Int32FromByteArray
 
     $value = [System.Int32] 0
     $value += [System.Int32] $Byte[$StartByte]
-    $value += [System.Int32] $Byte[$StartByte + 1] * 256
-    $value += [System.Int32] $Byte[$StartByte + 2] * 256 * 256
-    $value += [System.Int32] $Byte[$StartByte + 3] * 256 * 256 * 256
+    $value += [System.Int32] $Byte[$StartByte + 1] -shl 8
+    $value += [System.Int32] $Byte[$StartByte + 2] -shl 16
+    $value += [System.Int32] $Byte[$StartByte + 3] -shl 24
 
     return $value
 }

--- a/DSCResources/MSFT_ProxySettings/MSFT_ProxySettings.psm1
+++ b/DSCResources/MSFT_ProxySettings/MSFT_ProxySettings.psm1
@@ -560,7 +560,7 @@ function Test-ProxySettings
 function Get-StringLengthInHexBytes
 {
     [CmdletBinding()]
-    [OutputType([System.String[]])]
+    [OutputType([System.Object[]])]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/DSCResources/MSFT_ProxySettings/MSFT_ProxySettings.psm1
+++ b/DSCResources/MSFT_ProxySettings/MSFT_ProxySettings.psm1
@@ -554,7 +554,7 @@ function Test-ProxySettings
         Get the length of a string in the format of an array
         of hexidecimal format strings.
 
-    .PARAMETER String
+    .PARAMETER Value
         The string to return the length for.
 #>
 function Get-StringLengthInHexBytes
@@ -566,10 +566,10 @@ function Get-StringLengthInHexBytes
         [Parameter(Mandatory = $true)]
         [AllowEmptyString()]
         [System.String]
-        $String
+        $Value
     )
 
-    $hex = '{0:x8}' -f $String.Length
+    $hex = '{0:x8}' -f $Value.Length
     $stringLength = @()
     $stringLength += @('0x' + $hex.Substring(6,2))
     $stringLength += @('0x' + $hex.Substring(4,2))
@@ -698,7 +698,7 @@ function ConvertTo-ProxySettingsBinary
 
     if ($PSBoundParameters.ContainsKey('ProxyServer'))
     {
-        $proxySettings += Get-StringLengthInHexBytes -String $ProxyServer
+        $proxySettings += Get-StringLengthInHexBytes -Value $ProxyServer
         $proxySettings += [Byte[]][Char[]] $ProxyServer
     }
     else
@@ -714,7 +714,7 @@ function ConvertTo-ProxySettingsBinary
     if ($ProxyServerExceptions.Count -gt 0)
     {
         $proxyServerExceptionsString = $ProxyServerExceptions -join ';'
-        $proxySettings += Get-StringLengthInHexBytes -String $proxyServerExceptionsString
+        $proxySettings += Get-StringLengthInHexBytes -Value $proxyServerExceptionsString
         $proxySettings += [Byte[]][Char[]] $proxyServerExceptionsString
     }
     else
@@ -724,7 +724,7 @@ function ConvertTo-ProxySettingsBinary
 
     if ($PSBoundParameters.ContainsKey('AutoConfigURL'))
     {
-        $proxySettings += Get-StringLengthInHexBytes -String $AutoConfigURL
+        $proxySettings += Get-StringLengthInHexBytes -Value $AutoConfigURL
         $proxySettings += [Byte[]][Char[]] $AutoConfigURL
     }
 

--- a/Tests/Integration/MSFT_ProxySettings.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_ProxySettings.Integration.Tests.ps1
@@ -24,7 +24,7 @@ try
 {
     # Create a config data object to pass to the DSC Config
     $testProxyServer = 'testproxy:8888'
-    $testProxyExeceptions = 1..20 | Foreach-Object -Process {
+    $testProxyExceptions = 1..20 | Foreach-Object -Process {
         "exception$_.contoso.com"
     }
     $testAutoConfigURL = 'http://wpad.contoso.com/test.wpad'
@@ -37,7 +37,7 @@ try
                 EnableAutoConfiguration = $True
                 EnableManualProxy       = $True
                 ProxyServer             = $testProxyServer
-                ProxyServerExceptions   = $testProxyExeceptions
+                ProxyServerExceptions   = $testProxyExceptions
                 ProxyServerBypassLocal  = $True
                 AutoConfigURL           = $testAutoConfigURL
             }
@@ -83,7 +83,7 @@ try
             $current.EnableAutoConfiguration | Should -Be $True
             $current.EnableManualProxy       | Should -Be $True
             $current.ProxyServer             | Should -Be $testProxyServer
-            $current.ProxyServerExceptions   | Should -Be $testProxyExeceptions
+            $current.ProxyServerExceptions   | Should -Be $testProxyExceptions
             $current.ProxyServerBypassLocal  | Should -Be $True
             $current.AutoConfigURL           | Should -Be $testAutoConfigURL
         }

--- a/Tests/Integration/MSFT_ProxySettings.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_ProxySettings.Integration.Tests.ps1
@@ -24,7 +24,9 @@ try
 {
     # Create a config data object to pass to the DSC Config
     $testProxyServer = 'testproxy:8888'
-    $testProxyExeceptions = @('exception1.contoso.com', 'exception2.contoso.com')
+    $testProxyExeceptions = 1..20 | Foreach-Object -Process {
+        "exception$_.contoso.com"
+    }
     $testAutoConfigURL = 'http://wpad.contoso.com/test.wpad'
 
     $configData = @{

--- a/Tests/Unit/MSFT_ProxySettings.Tests.ps1
+++ b/Tests/Unit/MSFT_ProxySettings.Tests.ps1
@@ -28,10 +28,10 @@ try
 
         # Create the Mock Objects that will be used for running tests
         $testProxyServer = 'testproxy:8888'
-        $testProxyExeceptions = 1..20 | Foreach-Object -Process {
+        $testProxyExceptions = 1..20 | Foreach-Object -Process {
             "exception$_.contoso.com"
         }
-        $testProxyAlternateExeceptions = @('exception1.contoso.com')
+        $testProxyAlternateExceptions = @('exception1.contoso.com')
         $testAutoConfigURL = 'http://wpad.contoso.com/test.wpad'
 
         $testProxyAllDisabledSettings = [PSObject] @{
@@ -51,7 +51,7 @@ try
             EnableAutoDetection     = $False
             EnableManualProxy       = $True
             ProxyServer             = $testProxyServer
-            ProxyServerExceptions   = $testProxyExeceptions
+            ProxyServerExceptions   = $testProxyExceptions
             EnableAutoConfiguration = $False
         }
 
@@ -59,7 +59,7 @@ try
             EnableAutoDetection     = $False
             EnableManualProxy       = $True
             ProxyServer             = $testProxyServer
-            ProxyServerExceptions   = $testProxyAlternateExeceptions
+            ProxyServerExceptions   = $testProxyAlternateExceptions
             EnableAutoConfiguration = $False
         }
 
@@ -83,7 +83,7 @@ try
             EnableManualProxy       = $True
             ProxyServer             = $testProxyServer
             ProxyServerBypassLocal  = $False
-            ProxyServerExceptions   = $testProxyExeceptions
+            ProxyServerExceptions   = $testProxyExceptions
             EnableAutoConfiguration = $True
             AutoConfigURL           = $testAutoConfigURL
         }
@@ -93,7 +93,7 @@ try
             EnableManualProxy       = $True
             ProxyServer             = $testProxyServer
             ProxyServerBypassLocal  = $True
-            ProxyServerExceptions   = $testProxyExeceptions
+            ProxyServerExceptions   = $testProxyExceptions
             EnableAutoConfiguration = $True
             AutoConfigURL           = $testAutoConfigURL
         }
@@ -735,21 +735,21 @@ try
         }
 
         Describe "$script:DSCResourceName\Get-StringLengthInHexBytes" {
-            Context 'When an empty string is passed' {
+            Context 'When an empty value string is passed' {
                 It 'Should return @(0x00,0x00,0x00,0x00)' {
-                    Get-StringLengthInHexBytes -String '' | Should -Be @( '0x00', '0x00', '0x00', '0x00' )
+                    Get-StringLengthInHexBytes -Value '' | Should -Be @( '0x00', '0x00', '0x00', '0x00' )
                 }
             }
 
-            Context 'When a string less than 256 characters is passed' {
+            Context 'When a value string less than 256 characters is passed' {
                 It 'Should return @(0xFF,0x00,0x00,0x00)' {
-                    Get-StringLengthInHexBytes -String ([System.String]::new('a', 255)) | Should -Be @( '0xFF', '0x00', '0x00', '0x00' )
+                    Get-StringLengthInHexBytes -Value ([System.String]::new('a', 255)) | Should -Be @( '0xFF', '0x00', '0x00', '0x00' )
                 }
             }
 
-            Context 'When a string more than 256 characters is passed' {
+            Context 'When a value string more than 256 characters is passed' {
                 It 'Should return @(0x01,0x01,0x00,0x00)' {
-                    Get-StringLengthInHexBytes -String ([System.String]::new('a', 257)) | Should -Be @( '0x01', '0x01', '0x00', '0x00' )
+                    Get-StringLengthInHexBytes -Value ([System.String]::new('a', 257)) | Should -Be @( '0x01', '0x01', '0x00', '0x00' )
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the issue that occurs when strings longer than 255 chars are used.

#### This Pull Request (PR) fixes the following issues

- Fixes #378 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing for me if you have time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/networkingdsc/383)
<!-- Reviewable:end -->
