### PR TITLE
Fix bug in Firewall with RemoteAddress and LocalAddress - Fixes #404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   - Removing uneccesary `#region` blocks.
   - Conversion of double quotes to single quotes where possible.
   - Replace variables with string litterals in `describe` block description.
+- Firewall:
+  - Fix bug when LocalAddress or RemoteAddress is specified using CIDR
+    notation with number of bits specified in subnet mask (e.g.
+    10.0.0.1/8) rather than using CIDR subnet mask notation (e.g
+    10.0.0.1/255.0.0.0) - fixes [Issue #404](https://github.com/PowerShell/NetworkingDsc/issues/404).
 
 ## 7.2.0.0
 

--- a/DSCResources/MSFT_Firewall/MSFT_Firewall.psm1
+++ b/DSCResources/MSFT_Firewall/MSFT_Firewall.psm1
@@ -1208,7 +1208,10 @@ function Test-RuleProperties
                         format that the Get-NetFirewallAddressFilter will return the IP addresses in
                         even if they were set using CIDR notation.
                     #>
-                    $parameterNew = Convert-CIDRToSubhetMask -Address $parameterNew
+                    if ($null -ne $parameterNew)
+                    {
+                        $parameterNew = Convert-CIDRToSubhetMask -Address $parameterNew
+                    }
                 }
 
                 if ($parameterNew `

--- a/DSCResources/MSFT_Firewall/MSFT_Firewall.psm1
+++ b/DSCResources/MSFT_Firewall/MSFT_Firewall.psm1
@@ -1142,7 +1142,6 @@ function Test-RuleProperties
     )
 
     $properties = Get-FirewallRuleProperty -FirewallRule $FirewallRule
-
     $desiredConfigurationMatch = $true
 
     <#
@@ -1201,7 +1200,7 @@ function Test-RuleProperties
                     $parameterValue = $parameterValue -split $parameter.Delimiter
                 }
 
-                if ($parameter.Type -eq 'IPArray')
+                if ($parameter.Type -eq 'ArrayIP')
                 {
                     <#
                         IPArray comparison uses Compare-Object, except needs to convert any IP addresses


### PR DESCRIPTION
#### Pull Request (PR) description

Fix bug when LocalAddress or RemoteAddress is specified using CIDR
notation with number of bits specified in subnet mask (e.g.
10.0.0.1/8) rather than using CIDR subnet mask notation (e.g
10.0.0.1/255.0.0.0).

#### This Pull Request (PR) fixes the following issues

- Fixes #404 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/networkingdsc/407)
<!-- Reviewable:end -->
