### PR TITLE
Fix style violations in MSFT_DefaultGatewayAddress - Fixes #429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- DefaultGatewayAddress:
+  - Refactored to reduce code duplication.
+  - Fixed hash table style violations - fixes [Issue #429](https://github.com/PowerShell/NetworkingDsc/issues/429).
+  - Fixed general style violations.
+
 ## 7.4.0.0
 
 - Added Comment Based Help for `New-NotImplementedException` common

--- a/Tests/Unit/MSFT_DefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_DefaultGatewayAddress.Tests.ps1
@@ -50,7 +50,7 @@ try
             }
 
             Context 'When interface has no default gateway set' {
-                Mock -CommandName Get-NetRoute -MockWith { }
+                Mock -CommandName Get-NetRoute
 
                 It 'Should return no default gateway' {
                     $getTargetResourceParameters = @{
@@ -151,7 +151,7 @@ try
             }
 
             Context 'Checking return with default gateway but none are currently set' {
-                Mock -CommandName Get-NetRoute -MockWith { }
+                Mock -CommandName Get-NetRoute
 
                 It 'Should return false' {
                     $testTargetResourceParameters = @{
@@ -165,7 +165,7 @@ try
             }
 
             Context 'Checking return with no gateway and none are currently set' {
-                Mock -CommandName Get-NetRoute -MockWith { }
+                Mock -CommandName Get-NetRoute
 
                 It 'Should return true' {
                     $testTargetResourceParameters = @{
@@ -314,7 +314,7 @@ try
             }
 
             Context 'When interface has no default gateway set' {
-                Mock -CommandName Get-NetRoute -MockWith { }
+                Mock -CommandName Get-NetRoute
 
                 It 'Should return no default gateway' {
                     $GetNetDefaultRouteParameters = @{


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes hashtable style issues in DefaultGatewayAddress. It also cleans up some style issues and refactors some of the code.

#### This Pull Request (PR) fixes the following issues

- Fixes #429 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing for me when you have a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/networkingdsc/433)
<!-- Reviewable:end -->
